### PR TITLE
Save raw log to S3Log.raw

### DIFF
--- a/s3_log/reader.py
+++ b/s3_log/reader.py
@@ -16,6 +16,7 @@ class S3Log(object):
         if len(splited) < 6:
             return
         s = cls()
+        s.raw = row
         s.time = datetime.datetime.strptime(splited[0].split("+")[0], "%Y-%m-%dT%H:%M:%S.%f")
         s.ip = splited[1]
         s.label = splited[3]


### PR DESCRIPTION
把未处理的原始日志存到 `S3Log.raw` 上，方便调用者使用原始格式。
