### PR TITLE
replace warnings.warn with logging.warning

### DIFF
--- a/s3_log/reader.py
+++ b/s3_log/reader.py
@@ -3,7 +3,7 @@
 import boto3
 import botocore
 import datetime
-import warnings
+import logging
 
 from pytz import timezone
 
@@ -36,7 +36,7 @@ def get_key_list(client, bucket, prefix, time_begin):
     tz = timezone('Asia/Shanghai')
     resp = client.list_objects(Bucket=bucket, Prefix=prefix)
     if "Contents" not in resp:
-        warnings.warn("%s not found" % prefix)
+        logging.warning("%s not found" % prefix)
         return
 
     for obj in resp["Contents"]:

--- a/s3_log/reader.py
+++ b/s3_log/reader.py
@@ -8,6 +8,12 @@ import logging
 from pytz import timezone
 
 
+logger = logging.getLogger("s3-log")
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('%(levelname)s:%(name)s:%(message)s'))
+logger.addHandler(handler)
+
+
 class S3Log(object):
 
     @classmethod
@@ -36,7 +42,7 @@ def get_key_list(client, bucket, prefix, time_begin):
     tz = timezone('Asia/Shanghai')
     resp = client.list_objects(Bucket=bucket, Prefix=prefix)
     if "Contents" not in resp:
-        logging.warning("%s not found" % prefix)
+        logger.warning("%s not found" % prefix)
         return
 
     for obj in resp["Contents"]:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name='s3_log',
 
-    version='0.0.3',
+    version='0.0.4',
 
     description='s3 log utils',
     long_description='s3 log utils',


### PR DESCRIPTION
如文档中所说 [Logging HOWTO — Python 2.7.12 documentation](https://docs.python.org/2/howto/logging.html#when-to-use-logging)：

> warnings.warn() in library code if the issue is avoidable and the client application should be modified to eliminate the warning
> 
> logging.warning() if there is nothing the client application can do about the situation, but the event should still be noted

日志不存在应该更符合后者的情况。

同时用了 `logging.warning` 之后，调用方可以通过调节自己的 log level 来忽略一些提醒。
